### PR TITLE
Add ability to parse action url overrides 

### DIFF
--- a/lib/parse/blueprint.js
+++ b/lib/parse/blueprint.js
@@ -34,9 +34,20 @@ module.exports = function(filePath, autoOptions, routeMap) {
                 routeMap[key] = routeMap[key] || { urlExpression: key, methods: {} };
                 parseParameters(parsedUrl, resource.parameters, routeMap);
                 resource.actions.forEach(function(action){
-                    parseAction(parsedUrl, action, routeMap);
-                    saveRouteToTheList(parsedUrl, action);
+                    var actionUrl = setupActionUrl(action, parsedUrl, routeMap);
+                    parseAction(actionUrl, action, routeMap);
+                    saveRouteToTheList(actionUrl, action);
                 });
+            }
+
+            function setupActionUrl(action, resourceUrl, routeMap) {
+              if (action.attributes.uriTemplate !== '') {
+                var actionUrl = urlParser.parse(action.attributes.uriTemplate);
+                var actionKey = actionUrl.url;
+                routeMap[actionKey] = routeMap[actionKey] || { urlExpression: actionKey, methods: {} };
+                return actionUrl;
+              }
+              return resourceUrl;
             }
 
             /**

--- a/test/api/simple-api-test.js
+++ b/test/api/simple-api-test.js
@@ -28,6 +28,24 @@ describe('Simple-API', function(){
         });
     });
 
+    describe('/api/things/old', function(){
+        describe('GET', function(){
+            it('should respond with json collection from contract example', function(done){
+                request.get('/api/things/old')
+                .expect(200)
+                .expect('Content-type', 'application/json;charset=UTF-8')
+                .expect([
+                    {text: 'NES',id: '1'},
+                    {text: 'Atari', id: '2'},
+                    {text: 'The Beatles', id: '3'},
+                    {text: 'Grandma', id: '4'},
+                    {text: '80s', id: '5'}
+                ])
+                .end(helper.endCb(done));
+            });
+        });
+    });
+
     describe('/api/things/{thingId}', function(){
         describe('GET', function(){
             it('should respond with json object from contract example', function(done){

--- a/test/example/md/simple-api.md
+++ b/test/example/md/simple-api.md
@@ -33,7 +33,36 @@ Lists all the things from the API
                   "id": "5"
                 }
             ]
-            
+
+### Retrieve all the old things [GET /api/things/old]
+
++ Response 200 (application/json;charset=UTF-8)
+
+    + Body
+
+            [
+               {
+                  "text":"NES",
+                  "id": "1"
+                },
+               {
+                  "text":"Atari",
+                  "id": "2"
+                },
+               {
+                  "text":"The Beatles",
+                  "id": "3"
+                },
+               {
+                  "text":"Grandma",
+                  "id": "4"
+                },
+               {
+                  "text":"80s",
+                  "id": "5"
+                }
+            ]
+
 ### Create a new thing [POST]
 
 + Request (application/json)


### PR DESCRIPTION
The API blueprint [specification](https://apiblueprint.org/documentation/specification.html#def-action-section) defines an action as:

> Defined by an HTTP request method:
> 
> \<HTTP request method\>
> 
> -- or --
> 
> Defined by an action name (identifier) followed by an HTTP request method enclosed in square brackets [].
> 
> \<identifier\> [\<HTTP request method\>]
> 
> -- or --
> 
> Defined by an action name (identifier) followed by an HTTP request method and URI template enclosed in square brackets [].
> 
> \<identifier\> [\<HTTP request method\> \<URI template\>]

The last definition is not currently supported by Drakov as already mentioned in https://github.com/Aconex/drakov/issues/147. This PR fixes that.

